### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ orjson==3.9.10
 # Notify systemd
 sdnotify==0.3.2
 GitPython==3.1.42
-pyautogen==0.2.15
+ag2==0.2.15
 schedule==1.2.1
 croniter==2.0.3
 tabulate==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ required = [
     'orjson==3.9.10',
     'sdnotify==0.3.2',
     'GitPython==3.1.42',
-    'pyautogen==0.2.15',
+    'ag2==0.2.15',
     'schedule==1.2.1',
     'croniter==2.0.3',
     'tabulate==0.9.0',


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
